### PR TITLE
Simplify logic for restarting program with authentication

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -195,11 +195,7 @@ install() {
         read -p "[ Trusted ] Specify the root password : " -t${MAX_DELAY} -s
         [[ -n "$REPLY" ]] && {
         if [[ -n "${theme}" && -n "${screen}" ]]; then
-          if [[ ${THEME_DIR} == '/boot/grub/themes' ]]; then
-            sudo -S <<< $REPLY $0 --boot --${theme} --${icon} --${screen} --${custom_background}
-          else
-            sudo -S <<< $REPLY $0 --${theme} --${icon} --${screen} --${custom_background}
-          fi
+          sudo -S <<< $REPLY "$0" "${PROG_ARGS[@]}"
         fi
         } || {
              operation_canceled
@@ -346,11 +342,7 @@ remove() {
     read -p "[ trusted ] specify the root password : " -t${MAX_DELAY} -s
     [[ -n "$REPLY" ]] && {
       if [[ -n "${theme}" ]]; then
-        if [[ ${THEME_DIR} == '/boot/grub/themes' ]]; then
-          sudo -S <<< $REPLY $0 --remove --boot --${theme}
-        else
-          sudo -S <<< $REPLY $0 --remove --${theme}
-        fi
+        sudo -S <<< $REPLY "$0" "${PROG_ARGS[@]}"
       fi
     } || {
       operation_canceled
@@ -377,6 +369,7 @@ if [[ $# -lt 1 ]] && [[ $UID -ne $ROOT_UID ]] && [[ ! -x /usr/bin/dialog ]] ;  t
 fi
 
 while [[ $# -ge 1 ]]; do
+  PROG_ARGS+=("${1}")
   case "${1}" in
     -b|--boot)
       THEME_DIR="/boot/grub/themes"
@@ -413,9 +406,6 @@ while [[ $# -ge 1 ]]; do
       ;;
     -C|--custom-background|--custom)
       custom_background='custom-background'
-      ;;
-    -D|--default-background)
-      custom_background='default-background'
       ;;
     -r|--remove)
       remove='true'


### PR DESCRIPTION
 - Previously, each argument would be manually specified when the program is called again. After this change, the program is called with exactly the same arguments as it was originally. Doing this means the code doesn't have to detect whether or --boot was use and use a different command, and --default-background can be removed. (Both of these are in the pull request)