### PR TITLE
Fix arguments being passed while authenticating

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -205,7 +205,7 @@ install() {
     # persisted execution of the script as root
     if [[ -n ${tui_root_login} ]] ; then
         if [[ -n "${theme}" && -n "${screen}" ]]; then
-            sudo -S <<< ${tui_root_login} $0 --${theme} --${icon} --${screen} --${custom_background}
+            sudo -S <<< ${tui_root_login} $0 "${PROG_ARGS[@]}"
         fi
     else
         read -p "[ Trusted ] Specify the root password : " -t${MAX_DELAY} -s


### PR DESCRIPTION
## Changes:
 - If `tui_root_login` was used, not all arguments would be passed on during authentication, this is fixed by bringing it inline with the rest of the code