### PR TITLE
Installfix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ prompt () {
   esac
 }
 
-# Check command avalibility
+# Check command availability
 function has_command() {
   command -v $1 > /dev/null
 }
@@ -108,7 +108,7 @@ install() {
     local icon="color"
   fi
 
-  # Checking for root access and proceed if it is present
+  # Check for root access and proceed if it is present
   if [ "$UID" -eq "$ROOT_UID" ]; then
     clear
 
@@ -123,7 +123,7 @@ install() {
       fi
     fi
 
-    # Create themes directory if not exists
+    # Create themes directory if it didn't exist
     echo -e "\n Checking for the existence of themes directory..."
 
     [[ -d "${THEME_DIR}/${name}" ]] && rm -rf "${THEME_DIR}/${name}"
@@ -170,7 +170,7 @@ install() {
       echo "GRUB_THEME=\"${THEME_DIR}/${name}/theme.txt\"" >> /etc/default/grub
     fi
 
-    # Make sure set the right resolution for grub
+    # Make sure the right resolution for grub is set
     if [[ ${screen} == '1080p' ]]; then
       gfxmode="GRUB_GFXMODE=1920x1080,auto"
     elif [[ ${screen} == '1080p_21:9' ]]; then
@@ -208,7 +208,7 @@ install() {
     # Error message
     prompt -e "\n [ Error! ] -> Run me as root! "
 
-    # persisted execution of the script as root
+    # Persistent execution of the script as root
     if [[ -n ${tui_root_login} ]] ; then
         if [[ -n "${theme}" && -n "${screen}" ]]; then
             sudo -S <<< ${tui_root_login} $0 --${theme} --${icon} --${screen}
@@ -333,7 +333,7 @@ remove() {
     exit 0
   fi
 
-  # Checking for root access and proceed if it is present
+  # Check for root access and proceed if it is present
   if [ "$UID" -eq "$ROOT_UID" ]; then
     echo -e "\n Checking for the existence of themes directory..."
     if [[ -d "${THEME_DIR}/${name}" ]]; then
@@ -359,7 +359,7 @@ remove() {
     # Error message
     prompt -e "\n [ Error! ] -> Run me as root "
 
-    # persisted execution of the script as root
+    # Persistent execution of the script as root
     read -p "[ trusted ] specify the root password : " -t${MAX_DELAY} -s
     [[ -n "$REPLY" ]] && {
       if [[ -n "${theme}" ]]; then
@@ -371,7 +371,7 @@ remove() {
   fi
 }
 
-# show terminal user interface for better use
+# Show terminal user interface for better use
 if [[ $# -lt 1 ]] && [[ $UID -ne $ROOT_UID ]] && [[ -x /usr/bin/dialog ]] ; then
   run_dialog
 fi

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ b_CGSC=" \033[1;32m"                                # bold success color
 b_CRER=" \033[1;31m"                                # bold error color
 b_CWAR=" \033[1;33m"                                # bold warning color
 
-# echo like ...  with  flag type  and display message  colors
+# echo like ... with flag type and display message colors
 prompt () {
   case ${1} in
     "-s"|"--success")
@@ -91,15 +91,15 @@ install() {
     local screen="1080p"
   fi
 
+  if [[ ${screen} == '1080p_21:9' && ${name} == 'Slaze' ]]; then
+    prompt -e "ultrawide 1080p does not support Slaze theme"
+    exit 1
+  fi
+
   if [[ ${custom_background} == 'custom-background' ]]; then
     local custom_background="custom-background"
   else
     local custom_background="default-background"
-  fi
-
-  if [[ ${screen} == '1080p_21:9' && ${name} == 'Slaze' ]]; then
-    prompt -e "ultrawide 1080p does not support Slaze theme"
-    exit 1
   fi
 
   if [[ ${icon} == 'white' ]]; then
@@ -110,6 +110,7 @@ install() {
 
   # Check for root access and proceed if it is present
   if [ "$UID" -eq "$ROOT_UID" ]; then
+
     clear
 
     if [[ "${custom_background}" == "custom-background" ]]; then
@@ -214,7 +215,7 @@ install() {
             sudo -S <<< ${tui_root_login} $0 --${theme} --${icon} --${screen}
         fi
     else
-        read -p "[ Trusted ] Specify the root password : " -t${MAX_DELAY} -s
+        read -p " [ Trusted ] Specify the root password : " -t ${MAX_DELAY} -s
         [[ -n "$REPLY" ]] && {
         if [[ -n "${theme}" && -n "${screen}" ]]; then
           sudo -S <<< $REPLY "$0" --${theme} --${icon} --${screen}


### PR DESCRIPTION
[install.sh]

    Fixed the following issues :

    - The password prompt went all wonky if wrong password was entered.
    - The password prompt did not use system password cache and kept asking for password again on reruns of script, now if password is already cached user will not be asked anymore.
    - Installation failed if the script was initially ran by "sudo" due to inability to preserve ownership of asset files during cp commands, now the script can be ran by sudo or without sudo be asked for password on runtime.
    - The password prompt could be interrupted and rerun without at least blocking for few seconds first just like normal sudo failure in terminal.
    - The sudo command would no longer accept password from any commands if wrong password was given to the install script enough times (the only fix was restarting the system, I had to restart many times during testing...).