### PR TITLE
Add NixOS support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,91 @@
+{
+  description = "Flake to manage grub2 themes from vinceliuice";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+    in
+    with nixpkgs.lib;
+    rec {
+      nixosModule = { config, ... }:
+        let
+          cfg = config.boot.loader.grub2-theme;
+          resolutions = {
+            "1080p" = "1920x1080";
+            "ultrawide" = "2560x1080";
+            "2k" = "2560x1440";
+            "4k" = "3840x2160";
+            "ultrawide2k" = "3440x1440";
+          };
+          grub2-theme = pkgs.stdenv.mkDerivation {
+            name = "grub2-theme";
+            src = "${self}";
+            installPhase = ''
+              mkdir -p $out/grub/themes;
+              bash ./install.sh \
+                --generate $out/grub/themes \
+                --screen ${cfg.screen} \
+                --theme ${cfg.theme} \
+                --icon ${cfg.icon};
+            '';
+          };
+          resolution = resolutions."${cfg.screen}";
+        in
+        rec {
+          options = {
+            boot.loader.grub2-theme = {
+              theme = mkOption {
+                default = "tela";
+                example = "tela";
+                type = types.enum [ "tela" "vimix" "stylish" "whitesur" ];
+                description = ''
+                  The theme to use for grub2.
+                '';
+              };
+              icon = mkOption {
+                default = "white";
+                example = "white";
+                type = types.enum [ "color" "white" "whitesur" ];
+                description = ''
+                  The icon to use for grub2.
+                '';
+              };
+              screen = mkOption {
+                default = "1080p";
+                example = "1080p";
+                type = types.enum [ "1080p" "2k" "4k" "ultrawide" "ultrawide2k" ];
+                description = ''
+                  The screen resolution to use for grub2.
+                '';
+              };
+              splashImage = mkOption {
+                default = "";
+                example = "/my/path/background.jpg";
+                type = types.string;
+                description = ''
+                  The path of the image to use for background (must be jpg).
+                '';
+              };
+            };
+          };
+          config = mkMerge [{
+            environment.systemPackages = [
+              grub2-theme
+            ];
+            boot.loader.grub = {
+              theme = "${grub2-theme}/grub/themes/${cfg.theme}";
+              splashImage = "${grub2-theme}/grub/themes/${cfg.theme}/background.jpg";
+              gfxmodeEfi = "${resolution},auto";
+              gfxmodeBios = "${resolution},auto";
+            };
+          }];
+        };
+    };
+}

--- a/install.sh
+++ b/install.sh
@@ -599,4 +599,4 @@ if [[ "${dialog:-}" == 'false' ]]; then
   dialog_installer
 fi
 
-exit 1
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -69,8 +69,6 @@ usage() {
 }
 
 generate() {
-    clear
-
     # Make a themes directory if it doesn't exist
     prompt -s "\n Checking for the existence of themes directory..."
 
@@ -115,6 +113,8 @@ install() {
 
   # Check for root access and proceed if it is present
   if [[ "$UID" -eq "$ROOT_UID" ]]; then
+    clear
+
     # Generate the theme in "/usr/share/grub/themes"
     generate "${theme}" "${icon}" "${screen}"
 


### PR DESCRIPTION
Added a flake and module configuration options for installation on NixOS. During a nix build one should set

```nix
    boot.loader.grub2-theme = {                                                                                                                                                                                                               
      enable = true;                                                                                                                                                                                                              
      icon = "white";                                                                                                                                                                                                             
      theme = "whitesur";                                                                                                                                                                                                         
      screen = "1080p";                                                                                                                                                                                                           
      splashImage = ../../backgrounds/grub.jpg;                                                                                                                                                                                   
      footer = true;                                                                                                                                                                                                              
    };
```
in their configuration.

Moved the position of clear (no difference in usage), since this will break Nix on run.
No big deal if this is too big of a change for an obscure OS