### PR TITLE
Update install.sh to fix installation on Fedora 34 and later.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -312,7 +312,7 @@ updating_grub() {
   elif has_command zypper; then
     grub2-mkconfig -o /boot/grub2/grub.cfg
   elif has_command dnf; then
-    if [[ -f /boot/efi/EFI/fedora/grub.cfg ]]; then
+    if [[ -f /boot/efi/EFI/fedora/grub.cfg ]] && (( $(cat /etc/fedora-release | awk '{print $3}') < 34 )); then
       prompt -i "Find config file on /boot/efi/EFI/fedora/grub.cfg ...\n"
       grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
     fi


### PR DESCRIPTION
This fixes #156. A check for the Fedora Linux version is included in updating_grub so that `/boot/efi/EFI/fedora/grub.cfg` will not be overwritten on Fedora Linux 34 and later, as described [here](https://fedoraproject.org/wiki/GRUB_2#Updating_the_GRUB_configuration_file).