### PR TITLE
Make splashImage option a `nullOr` type

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
       nixosModule = { config, ... }:
         let
           cfg = config.boot.loader.grub2-theme;
+          splashImage = if cfg.splashImage == null then "" else cfg.splashImage;
           resolutions = {
             "1080p" = "1920x1080";
             "ultrawide" = "2560x1080";
@@ -35,8 +36,8 @@
                 --theme ${cfg.theme} \
                 --icon ${cfg.icon};
 
-              if [ -f ${cfg.splashImage} ]; then
-                cp ${cfg.splashImage} $out/grub/themes/${cfg.theme}/background.jpg;
+              if [ -n "${splashImage}" ]; then
+                cp ${splashImage} $out/grub/themes/${cfg.theme}/background.jpg;
               fi;
               if [ ${pkgs.lib.trivial.boolToString cfg.footer} == "false" ]; then
                 sed -i ':again;$!N;$!b again; s/\+ image {[^}]*}//g' $out/grub/themes/${cfg.theme}/theme.txt;
@@ -81,9 +82,9 @@
                 '';
               };
               splashImage = mkOption {
-                default = "";
+                default = null;
                 example = "/my/path/background.jpg";
-                type = types.path;
+                type = types.nullOr types.path;
                 description = ''
                   The path of the image to use for background (must be jpg).
                 '';


### PR DESCRIPTION
Currently importing the nixos module with a plain config fails with the error:
```
❯ sudo nixos-rebuild switch --flake .
building the system configuration...
warning: Git tree '/home/thomassdk/.config/nixos' is dirty
error: A definition for option `boot.loader.grub2-theme.splashImage' is not of type `path'. Definition values:
       - In `/nix/store/y623x85i3kh5r56k0wzx2rq0liprbmy7-source/hosts/stargazer': ""
(use '--show-trace' to show detailed location information)
```
Config:
```
grub2-theme = {
  enable = true;
};
```
This fixes that allowing the configuration to build and use the default splashImage of the theme