### PR TITLE
Remove override of THEME_DIR

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -459,7 +459,6 @@ while [[ $# -gt 0 ]]; do
   dialog='false'
   case "${1}" in
     -b|--boot)
-      THEME_DIR="/boot/grub/themes"
       shift 1
       ;;
     -r|--remove)


### PR DESCRIPTION
This change fixes the removal of themes. When using the -b flag, the script will install the theme to /boot/grub/themes but when removing the theme, the script is using /usr/share/grub/themes path and obviously the theme won't be there.