### PR TITLE
flake.nix: Change deprecated string type to str

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,7 @@
               bootMenuConfig = mkOption {
                 default = null;
                 example = "left = 30%";
-                type = types.nullOr types.string;
+                type = types.nullOr types.str;
                 description = ''
                   Grub theme definition for boot_menu.
                   Refer to config/theme-*.txt for reference.
@@ -122,7 +122,7 @@
               terminalConfig = mkOption {
                 default = null;
                 example = "terminal-font: \"Terminus Regular 18\"";
-                type = types.nullOr types.string;
+                type = types.nullOr types.str;
                 description = ''
                   Replaces grub theme definition for terminial-*.
                   Refer to config/theme-*.txt for reference.


### PR DESCRIPTION
silences 
`trace: warning: The type types.string is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.`