### PR TITLE
added opensuse microOS and Fedora Atomic Desktop commands

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -352,13 +352,17 @@ updating_grub() {
     update-grub
   elif has_command grub-mkconfig; then
     grub-mkconfig -o /boot/grub/grub.cfg
-  elif has_command zypper; then
+  # Check for OpenSuse (regular or microOS)
+  elif has_command zypper || has_command transactional-update; then
     grub2-mkconfig -o /boot/grub2/grub.cfg
-  elif has_command dnf; then
-    if [[ -f /boot/efi/EFI/fedora/grub.cfg ]] && (( $(cat /etc/fedora-release | awk '{print $3}') < 34 )); then
+  # Check for Fedora (regular or Atomic)
+  elif has_command dnf || has_command rpm-ostree; then
+    # check for UEFI
+    if [[ -f /boot/efi/EFI/fedora/grub.cfg ]]; then
       prompt -s "Find config file on /boot/efi/EFI/fedora/grub.cfg ...\n"
       grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
     fi
+    # Check for Bios
     if [[ -f /boot/grub2/grub.cfg ]]; then
       prompt -s "Find config file on /boot/grub2/grub.cfg ...\n"
       grub2-mkconfig -o /boot/grub2/grub.cfg


### PR DESCRIPTION
Applying those works on Fedora Atomic! It should work the same on OpenSuse microOS as on regular OpenSuse too.

So I added the respective "immutable Desktop" installer commands to test for the Distro. Also removed the "test for Fedora > 34" as nobody uses that anymore.

Great work!