### PR TITLE
flake.nix simplified splashImage changing

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,12 +39,8 @@
                 --icon ${cfg.icon};
 
               if [ -n "${splashImage}" ]; then
-                filename=$(basename -- "${splashImage}")
-                extension="''${filename##*.}"
                 rm $out/grub/themes/${cfg.theme}/background.jpg;
-                cp ${splashImage} $out/grub/themes/${cfg.theme}/background.$extension;
-                cp ${splashImage} $out/grub/themes/${cfg.theme}/background;
-                sed -i "s/background.jpg/background.$extension/g" $out/grub/themes/${cfg.theme}/theme.txt;
+                ${pkgs.imagemagick}/bin/convert ${splashImage} $out/grub/themes/${cfg.theme}/background.jpg;
               fi;
               if [ ${pkgs.lib.trivial.boolToString cfg.footer} == "false" ]; then
                 sed -i ':again;$!N;$!b again; s/\+ image {[^}]*}//g' $out/grub/themes/${cfg.theme}/theme.txt;


### PR DESCRIPTION
Fixed problem that occurred when setting custom splash image for NixOS.


Earlier there was problem when using custom image for grub background and caused grub theme to not work at all.

Preview of borked theme:
![IMG_20240216_151931](https://github.com/vinceliuice/grub2-themes/assets/76793870/85df4ea0-2dc2-417a-bdc2-f629433a44e1)

To reproduce:
Set any path of image into splashImage attribute. (it was a nix store path in my case)

This patch fixes that problem.