### PR TITLE
fix: fixed grub.cfg directory issues in install.sh for fedora

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -347,9 +347,9 @@ updating_grub() {
     grub2-mkconfig -o /boot/grub2/grub.cfg
   # Check for Fedora (regular or Atomic)
   elif has_command dnf || has_command rpm-ostree; then 
-    if [[ -f /etc/grub2.cfg ]]; then
-      prompt -s "Find config file on /etc/grub2.cfg ...\n"
-      grub2-mkconfig -o /etc/grub2.cfg
+    if [[ -f /boot/grub2/grub.cfg ]]; then
+      prompt -s "Find config file on /boot/grub2/grub.cfg ...\n"
+      grub2-mkconfig -o /boot/grub2/grub.cfg
     fi
     # Check for Bios
     if [[ -f /boot/grub2/grub.cfg ]]; then

--- a/install.sh
+++ b/install.sh
@@ -347,11 +347,7 @@ updating_grub() {
     grub2-mkconfig -o /boot/grub2/grub.cfg
   # Check for Fedora (regular or Atomic)
   elif has_command dnf || has_command rpm-ostree; then 
-    if [[ -f /boot/grub2/grub.cfg ]]; then
-      prompt -s "Find config file on /boot/grub2/grub.cfg ...\n"
-      grub2-mkconfig -o /boot/grub2/grub.cfg
-    fi
-    # Check for Bios
+    #Check for BIOS
     if [[ -f /boot/grub2/grub.cfg ]]; then
       prompt -s "Find config file on /boot/grub2/grub.cfg ...\n"
       grub2-mkconfig -o /boot/grub2/grub.cfg

--- a/install.sh
+++ b/install.sh
@@ -160,14 +160,6 @@ install() {
           #Append GRUB_FONT
           echo "GRUB_FONT=/boot/grub2/fonts/unicode.pf2" >> /etc/default/grub
         fi
-      elif [[ -f "/boot/efi/EFI/fedora/fonts/unicode.pf2" ]]; then
-        if grep "GRUB_FONT=" /etc/default/grub 2>&1 >/dev/null; then
-          #Replace GRUB_FONT
-          sed -i "s|.*GRUB_FONT=.*|GRUB_FONT=/boot/efi/EFI/fedora/fonts/unicode.pf2|" /etc/default/grub
-        else
-          #Append GRUB_FONT
-          echo "GRUB_FONT=/boot/efi/EFI/fedora/fonts/unicode.pf2" >> /etc/default/grub
-        fi
       fi
     fi
 
@@ -354,9 +346,8 @@ updating_grub() {
   elif has_command zypper || has_command transactional-update; then
     grub2-mkconfig -o /boot/grub2/grub.cfg
   # Check for Fedora (regular or Atomic)
-  elif has_command dnf || has_command rpm-ostree; then
-    # DON'T TOUCH UEFI 
-    if [[ -f /boot/efi/EFI/fedora/grub.cfg ]]; then
+  elif has_command dnf || has_command rpm-ostree; then 
+    if [[ -f /etc/grub2.cfg ]]; then
       prompt -s "Find config file on /etc/grub2.cfg ...\n"
       grub2-mkconfig -o /etc/grub2.cfg
     fi

--- a/install.sh
+++ b/install.sh
@@ -77,12 +77,10 @@ EOF
 
 generate() {
   if [[ "${install_boot}" == 'true' ]]; then
-    if [[ -d "/boot/efi/EFI/fedora" ]]; then
-      THEME_DIR='/boot/efi/EFI/fedora/themes'
-    fi
     if [[ -d "/boot/grub" ]]; then
       THEME_DIR='/boot/grub/themes'
-    elif [[ -d "/boot/grub2" ]]; then
+    fi
+    if [[ -d "/boot/grub2" ]]; then
       THEME_DIR='/boot/grub2/themes'
     fi
   fi
@@ -357,10 +355,10 @@ updating_grub() {
     grub2-mkconfig -o /boot/grub2/grub.cfg
   # Check for Fedora (regular or Atomic)
   elif has_command dnf || has_command rpm-ostree; then
-    # check for UEFI
+    # DON'T TOUCH UEFI 
     if [[ -f /boot/efi/EFI/fedora/grub.cfg ]]; then
-      prompt -s "Find config file on /boot/efi/EFI/fedora/grub.cfg ...\n"
-      grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
+      prompt -s "Find config file on /etc/grub2.cfg ...\n"
+      grub2-mkconfig -o /etc/grub2.cfg
     fi
     # Check for Bios
     if [[ -f /boot/grub2/grub.cfg ]]; then


### PR DESCRIPTION
Addresses issue #215 by removing `/boot/efi/EFI/fedora/grub.cfg` directories and replacing it with `/boot/grub2/grub.cfg` wherever needed. 

Tried the new changes on my Fedora 39 workstation and it works fine