### PR TITLE
Nix: fix extension of splashImage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -139,13 +139,10 @@
               grub2-theme
             ];
             boot.loader.grub =
-              let
-                ext = if cfg.splashImage == null then "jpg" else last (splitString "." cfg.splashImage);
-              in
               {
                 theme = "${grub2-theme}/grub/themes/${cfg.theme}";
                 splashImage =
-                  "${grub2-theme}/grub/themes/${cfg.theme}/background.${ext}";
+                  "${grub2-theme}/grub/themes/${cfg.theme}/background.jpg";
                 gfxmodeEfi = "${resolution},auto";
                 gfxmodeBios = "${resolution},auto";
                 extraConfig = ''


### PR DESCRIPTION
PR https://github.com/vinceliuice/grub2-themes/pull/212 introduced always converting the `splashImage` to `.jpg` using `imagemagick`:
https://github.com/vinceliuice/grub2-themes/blob/eda1b86dd8e991ea0c03090ff60b4c0b63799489/flake.nix#L43

Therefore, https://github.com/vinceliuice/grub2-themes/blob/eda1b86dd8e991ea0c03090ff60b4c0b63799489/flake.nix#L147-L148 should also always use the `jpg` extension. This fixes `png` images not working.