### PR TITLE
Update ImageMagick command for GRUB theme background

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
 
               if [ -n "${splashImage}" ]; then
                 rm $out/grub/themes/${cfg.theme}/background.jpg;
-                ${pkgs.imagemagick}/bin/convert ${splashImage} $out/grub/themes/${cfg.theme}/background.jpg;
+                ${pkgs.imagemagick}/bin/magick ${splashImage} $out/grub/themes/${cfg.theme}/background.jpg;
               fi;
               if [ ${pkgs.lib.trivial.boolToString cfg.footer} == "false" ]; then
                 sed -i ':again;$!N;$!b again; s/\+ image {[^}]*}//g' $out/grub/themes/${cfg.theme}/theme.txt;


### PR DESCRIPTION
## Description
This PR updates the ImageMagick command used to convert the splash image for the GRUB theme background. The change replaces the deprecated `convert` command with the newer `magick` command, which is the recommended syntax for ImageMagick 7.

## Changes
- Updated the ImageMagick command in `flake.nix` from:
  ```
  ${pkgs.imagemagick}/bin/convert ${splashImage} $out/grub/themes/${cfg.theme}/background.jpg;
  ```
  to:
  ```
  ${pkgs.imagemagick}/bin/magick ${splashImage} $out/grub/themes/${cfg.theme}/background.jpg;
  ```

## Tests
- The NixOS configuration was rebuilt using `nh os switch`.
- The GRUB theme was visually inspected on system reboot to confirm the background image is correctly applied.
- Verified that no deprecation warnings related to ImageMagick are displayed during the build process.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Additional Notes
This change is a simple syntax update and should not affect the functionality of the GRUB theme installation. It only modifies our use of ImageMagick to align with current best practices.