### PR TITLE
Fix NixOS build failure due to missing files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,15 @@
             src = "${self}";
             buildInputs = [ pkgs.imagemagick ];
             installPhase = ''
-              mkdir -p $out/grub/themes;
+              mkdir -p $out/grub/themes
+
+              # Create placeholder terminal box PNGs that install.sh expects
+              mkdir -p common
+              for box in c e n ne nw s se sw w; do
+                touch common/terminal_box_$box.png
+              done
+
+              # Run the install script
               bash ./install.sh \
                 --generate $out/grub/themes \
                 --screen ${cfg.screen} \
@@ -44,9 +52,11 @@
                 rm $out/grub/themes/${cfg.theme}/background.jpg;
                 ${pkgs.imagemagick}/bin/magick ${splashImage} $out/grub/themes/${cfg.theme}/background.jpg;
               fi;
+
               if [ ${pkgs.lib.trivial.boolToString cfg.footer} == "false" ]; then
                 sed -i ':again;$!N;$!b again; s/\+ image {[^}]*}//g' $out/grub/themes/${cfg.theme}/theme.txt;
               fi;
+
               if [ ${pkgs.lib.trivial.boolToString hasBootMenuConfig} == "true" ]; then
                 sed -i ':again;$!N;$!b again; s/\+ boot_menu {[^}]*}//g' $out/grub/themes/${cfg.theme}/theme.txt;
                 cat << EOF >> $out/grub/themes/${cfg.theme}/theme.txt
@@ -55,6 +65,7 @@
               }
               EOF
               fi;
+
               if [ ${pkgs.lib.trivial.boolToString hasTerminalConfig} == "true" ]; then
                 sed -i 's/^terminal-.*$//g' $out/grub/themes/${cfg.theme}/theme.txt
                 cat << EOF >> $out/grub/themes/${cfg.theme}/theme.txt


### PR DESCRIPTION
# Description:
Fixes #234 

The NixOS flake system rebuild was failing due to missing files expected by install.sh. This PR updates flake.nix to handle missing files by creating required placeholders and I modified flake.nix to create necessary placeholder files before running install.sh

Test successful on my machine.

My NixOS config:
```nix
    loader.grub2-theme = {
      enable = true;
      theme = "stylish";
      customResolution = "2880x1800";
      icon = "color"
      footer = true;
    };
```