### PR TITLE
Fix background in terminal

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -213,11 +213,8 @@ install() {
     fi
 
     if grep "GRUB_BACKGROUND=" /etc/default/grub 2>&1 >/dev/null; then
-      #Replace GRUB_BACKGROUND
-      sed -i "s|.*GRUB_BACKGROUND=.*|GRUB_BACKGROUND=\"${THEME_DIR}/${theme}/background.jpg\"|" /etc/default/grub
-    else
-      #Append GRUB_BACKGROUND
-      echo "GRUB_BACKGROUND=\"${THEME_DIR}/${theme}/background.jpg\"" >> /etc/default/grub
+      # remove GRUB_BACKGROUND
+      sed -i "s|.*GRUB_BACKGROUND=.*||" /etc/default/grub
     fi
 
     # Make sure the right resolution for grub is set


### PR DESCRIPTION
Becoz of GRUB_BACKGROUND being set it shows backkground in grub terminal too which is highly discouraged as it reduces visibilty of texts to 10-30%  

so better keep the terminal and other screen black expect the grub menu which is already set by theme  ```desktop-image```