### PR TITLE
fix: use convert as fallback for imagemagick v6

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Define which command to use for ImageMagick
+if command -v magick &> /dev/null; then
+  _MAGICK="magick"
+else
+  _MAGICK="convert"
+fi
+
 # Exit Immediately if a command fails
 set -o errexit
 
@@ -127,7 +134,7 @@ generate() {
     sed -i "s/[0-9]\+x[0-9]\+/${custom_resolution}/" "${THEME_DIR}/${theme}/theme.txt"
     # Use appropriate background as base and resize it
     cp -a --no-preserve=ownership "${REO_DIR}/backgrounds/${asset_type}/background-${theme}.jpg" "${THEME_DIR}/${theme}/background.jpg"
-    magick "${THEME_DIR}/${theme}/background.jpg" -resize ${custom_resolution}^ -gravity center -extent ${custom_resolution} "${THEME_DIR}/${theme}/background.jpg"
+    "${_MAGICK}" "${THEME_DIR}/${theme}/background.jpg" -resize ${custom_resolution}^ -gravity center -extent ${custom_resolution} "${THEME_DIR}/${theme}/background.jpg"
   else
     cp -a --no-preserve=ownership "${REO_DIR}/config/theme-${screen}.txt" "${THEME_DIR}/${theme}/theme.txt"
     cp -a --no-preserve=ownership "${REO_DIR}/backgrounds/${screen}/background-${theme}.jpg" "${THEME_DIR}/${theme}/background.jpg"
@@ -142,7 +149,7 @@ generate() {
     fi
     prompt -w "\n Using custom background.jpg as grub background image..."
     cp -a --no-preserve=ownership "${REO_DIR}/background.jpg" "${THEME_DIR}/${theme}/background.jpg"
-    magick "${THEME_DIR}/${theme}/background.jpg" -auto-orient "${THEME_DIR}/${theme}/background.jpg"
+     "${_MAGICK}" "${THEME_DIR}/${theme}/background.jpg" -auto-orient "${THEME_DIR}/${theme}/background.jpg"
   fi
 
   # Determine which assets to use based on custom resolution or screen


### PR DESCRIPTION
**First of all, thank you for this amazing project! These GRUB themes are incredibly well-designed and bring a modern look to my Linux setup.**

On some stable distributions like Ubuntu 24.04 LTS, ImageMagick v6 is still the default, which uses the convert command instead of magick. This PR adds a fallback check to ensure compatibility across different ImageMagick versions.

Here is **the problem** before altering the code.
On Ubuntu 24.04 LTS (ImageMagick v6), the script fails because the magick command does not exist:
<img width="1325" height="567" alt="图片" src="https://github.com/user-attachments/assets/865a78e8-2c89-461d-8da0-bc3e5508f248" />

After altering the code, **the script correctly handles the command fallback**. Here is the successful output:
alexander-ThinkBook-16-G7-IAH% sudo ./install.sh -t stylish -c 3200x1600
<img width="1323" height="113" alt="图片" src="https://github.com/user-attachments/assets/5d8ec967-16ce-4bee-af4d-330c30ff772c" />

**Thanks again for your hard work on these themes!**